### PR TITLE
GitHub Pages support

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,0 +1,46 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy static content to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install NPM Packages
+        uses: bahmutov/npm-install@v1
+      - name: Build project
+        run: npm run build
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload entire repository
+          path: './build'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,6 +34,8 @@ jobs:
         uses: bahmutov/npm-install@v1
       - name: Build project
         run: npm run build
+        env:
+          CI: "false"
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Upload artifact

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "pokemon-sv-food-sim",
   "version": "0.1.0",
   "private": true,
+  "homepage": "https://cecilbowen.github.io/pokemon-sandwich-simulator",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",

--- a/src/App.css
+++ b/src/App.css
@@ -206,3 +206,7 @@
     transform: rotate(360deg);
   }
 }
+
+small {
+  font-size: 0.7em;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -745,6 +745,7 @@ function App() {
       {renderMath()}
       {renderSearch()}
       {renderSettings()}
+      <small><a href="https://github.com/cecilbowen/pokemon-sandwich-simulator">Source Code</a></small>
     </div>
   );
 }


### PR DESCRIPTION
This pull request adds support for automatic deployment to [GitHub Pages](https://pages.github.com/), a free static web hosting service by GitHub. Every commit to the master branch will be automatically compiled and deployed.

In order to use, you'll need to enable GitHub Pages in the repository settings:

![image](https://user-images.githubusercontent.com/4109551/205216104-3ddaeb39-3f68-403d-aa76-62293c68a61c.png)

I have this setup on the fork I used to submit this pull request and the result can be previewed here: 

https://au5ton.github.io/pokemon-sandwich-simulator/

Should you accept this pull request, yours will likely be:

https://cecilbowen.github.io/pokemon-sandwich-simulator/