### PR TITLE
Add list of all types and powers to sort ingridients

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -129,8 +129,8 @@
   margin-top: 10px;
 }
 
-.complex-search-panel {
-  margin-bottom: 10px;
+.complex-search-panel > * {
+  margin-bottom:6px;
 }
 
 .settings-bar {
@@ -204,7 +204,6 @@
   margin: 2px;
   cursor: pointer;
 }
-
 
 .bubble-min-width {
   min-width: 80px;

--- a/src/App.css
+++ b/src/App.css
@@ -129,6 +129,10 @@
   margin-top: 10px;
 }
 
+.complex-search-panel {
+  margin-bottom: 10px;
+}
+
 .settings-bar {
   margin: 10px 0px 10px 0px;
 }
@@ -192,13 +196,19 @@
   display: flex;
   user-select: none;
   border-radius: 25px;
-  padding: 4px;
+  padding: 4px 8px;
   width: fit-content;
   height: fit-content;
   font-family: monospace;
   font-size: 14px;
   margin: 2px;
   cursor: pointer;
+}
+
+
+.bubble-min-width {
+  min-width: 80px;
+  justify-content: center;
 }
 
 .bubble-type {

--- a/src/App.js
+++ b/src/App.js
@@ -2,6 +2,7 @@ import SANDWICHES from './data/sandwiches.json';
 import FILLINGS from './data/fillings.json';
 import CONDIMENTS from './data/condiments.json';
 import POWERS from './data/powers.json';
+import TYPES from './data/types.json';
 import { useEffect, useState } from 'react';
 import { getCondiments, getFillings,
   ALIAS_TO_FULL, COLORS, oneTwoFirst, getIngredientsSums, craftSandwich, checkPresetSandwich,
@@ -9,6 +10,7 @@ import { getCondiments, getFillings,
 import { runTests } from './test/tests';
 import Card from './components/Card';
 import './App.css';
+import Bubble from './components/Bubble';
 
 // per player
 const MAX_FILLINGS = 6;
@@ -429,6 +431,40 @@ function App() {
     );
   };
 
+  const renderComplexSearch = () => {
+    return (
+      <div className="complex-search-panel">
+        <div>
+          <h5 className="search-heading">Powers:</h5>
+          <div className="bubble-row">
+            {Object.keys(ALIAS_TO_FULL).map((power) => (
+              <Bubble
+                label={power}
+                key={power}
+                onClick={() => toggleActiveKey(power)}
+                selected={activeKey && Object.values(activeKey).indexOf(power) !== -1}
+              />
+            ))}
+          </div>
+        </div>
+        <div>
+          <h5 className="search-heading">Types:</h5>
+          <div className="bubble-row">
+            {TYPES.map((type) => (
+              <Bubble
+                label={type}
+                key={type}
+                isType
+                onClick={() => toggleActiveKey(type)}
+                selected={activeKey && Object.values(activeKey).indexOf(type) !== -1}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const saveRecipe = () => {
     if (activeCondiments.length === 0) { return; }
 
@@ -476,6 +512,7 @@ function App() {
 
   return (
     <div className="App">
+      {!simpleMode && renderComplexSearch()}
       {renderFillings()}
       {renderCondiments()}
       {renderActive()}

--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,8 @@
 import SANDWICHES from './data/sandwiches.json';
 import FILLINGS from './data/fillings.json';
 import CONDIMENTS from './data/condiments.json';
-import POWERS from './data/powers.json';
 import TYPES from './data/types.json';
+import FLAVORS from './data/flavors.json';
 import { useEffect, useState } from 'react';
 import { getCondiments, getFillings,
   ALIAS_TO_FULL, COLORS, oneTwoFirst, getIngredientsSums, craftSandwich, checkPresetSandwich,
@@ -434,32 +434,42 @@ function App() {
   const renderComplexSearch = () => {
     return (
       <div className="complex-search-panel">
-        <div>
-          <h5 className="search-heading">Powers:</h5>
-          <div className="bubble-row">
-            {Object.keys(ALIAS_TO_FULL).map((power) => (
-              <Bubble
-                label={power}
-                key={power}
-                onClick={() => toggleActiveKey(power)}
-                selected={activeKey && Object.values(activeKey).indexOf(power) !== -1}
-              />
-            ))}
-          </div>
+        <div className="bubble-row">
+          {FLAVORS.map((flavor) => (
+            <Bubble
+              label={flavor}
+              key={flavor}
+              onClick={() => toggleActiveKey(flavor)}
+              selected={
+                activeKey && Object.values(activeKey).indexOf(flavor) !== -1
+              }
+            />
+          ))}
         </div>
-        <div>
-          <h5 className="search-heading">Types:</h5>
-          <div className="bubble-row">
-            {TYPES.map((type) => (
-              <Bubble
-                label={type}
-                key={type}
-                isType
-                onClick={() => toggleActiveKey(type)}
-                selected={activeKey && Object.values(activeKey).indexOf(type) !== -1}
-              />
-            ))}
-          </div>
+        <div className="bubble-row">
+          {Object.keys(ALIAS_TO_FULL).map((power) => (
+            <Bubble
+              label={power}
+              key={power}
+              onClick={() => toggleActiveKey(power)}
+              selected={
+                activeKey && Object.values(activeKey).indexOf(power) !== -1
+              }
+            />
+          ))}
+        </div>
+        <div className="bubble-row">
+          {TYPES.map((type) => (
+            <Bubble
+              label={type}
+              key={type}
+              isType
+              onClick={() => toggleActiveKey(type)}
+              selected={
+                activeKey && Object.values(activeKey).indexOf(type) !== -1
+              }
+            />
+          ))}
         </div>
       </div>
     );

--- a/src/components/Bubble.js
+++ b/src/components/Bubble.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { COLORS } from "../util";
+
+const Bubble = ({ label, isType, onClick, selected }) => {
+  const backgroundColor = COLORS[label];
+  let borderColor = selected ? "black" : backgroundColor;
+
+  return (
+    <div
+      className={`bubble bubble-min-width  ${isType ? "bubble-type" : ""} ${
+        selected ? "key-selected" : "fake-border"
+      }`}
+      onClick={onClick}
+      style={{ backgroundColor, borderColor }}
+    >
+      {label}
+    </div>
+  );
+};
+
+export default Bubble;


### PR DESCRIPTION
Hi, i really like your tool, but i felt like it was missing the list of all types and powers to sort ingridients. (Searches only sorted recepies.) So i added one.
It looks like this and is visible when Simple mode is turned OFF:
![preview](https://user-images.githubusercontent.com/49321699/206529952-06253687-821e-41a1-a7cd-522915952913.png)

I hope you like it ^_^
