### PR TITLE
fixed strings-zh-TW 'Sliced Egg' mismatch

### DIFF
--- a/src/language/strings-zh-TW.json
+++ b/src/language/strings-zh-TW.json
@@ -8,7 +8,7 @@
     "Cherry Tomatoes": "小番茄塊",
     "Chorizo": "煎辣香腸",
     "Cucumber": "小黃瓜片",
-    "Sliced Egg": "小辣椒",
+    "Sliced Egg": "水煮蛋片",
     "Fried Fillet": "炸魚片",
     "Green Bell Pepper": "青椒片",
     "Ham": "火腿片",


### PR DESCRIPTION
Thank you for this awesome tool! Just found a small mismatch in the zh-TW translation file, this PR is for updating it.