### PR TITLE
Fix effects for ultra tower sandwich recipe

### DIFF
--- a/src/data/sandwiches.json
+++ b/src/data/sandwiches.json
@@ -6688,7 +6688,7 @@
       {
         "name": "Catching Power",
         "type": "Normal",
-        "level": "2"
+        "level": "1"
       }
     ],
     "imageUrl": "https://www.serebii.net/scarletviolet/sandwich/146.jpg",


### PR DESCRIPTION
It was brought to my attention that there is an inaccuracy in the source data for the Ultra Tower Sandwich. The source data says it gives Lv. 2 Catching Power Normal, but it's actually Lv. 1.

![IMG_4953](https://user-images.githubusercontent.com/51864364/224854036-45e99a81-80f1-4b3e-b4c1-2c83c6dfa0f7.jpeg)

![IMG_4952](https://user-images.githubusercontent.com/51864364/224854059-00049c41-23bb-47fc-95a8-493cb34b13c8.jpeg)
